### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/chincherpa/todos)](https://repl.it/github/chincherpa/todos)
+
 # Todos in terminal
 ![alt text](screenshot0.jpg)
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@chincherpa/todos).